### PR TITLE
update ci

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,7 +22,7 @@ jobs:
     runs-on: azure-eng
     steps:
       - name: Read Configuration
-        uses: hashicorp/vault-action@v2.4.3
+        uses: hashicorp/vault-action@v2.5.0
         id: vault
         with:
           url: ${{ env.VAULT_ADDR }}
@@ -33,7 +33,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Setup Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
       - name: Setup caching
@@ -73,7 +73,7 @@ jobs:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     steps:
       - name: Read Configuration
-        uses: hashicorp/vault-action@v2.4.3
+        uses: hashicorp/vault-action@v2.5.0
         id: vault
         with:
           url: ${{ env.VAULT_ADDR }}
@@ -88,7 +88,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Setup Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
       - name: Setup caching


### PR DESCRIPTION
Update CI to use the latest hashicorp/vault-action@v2.5.0 and actions/setup-go@v4 actions.
